### PR TITLE
Use slightly better vtkm api

### DIFF
--- a/createTangleField.cpp
+++ b/createTangleField.cpp
@@ -19,6 +19,9 @@
 #include <ospray/ospcommon/box.h>
 // std
 #include <memory>
+//vtkm
+#include <vtkm/worklet/Invoker.h>
+#include <vtkm/worklet/WorkletMapField.h>
 
 namespace ospray {
   namespace vtkm_demo_plugin {
@@ -74,9 +77,9 @@ namespace ospray {
       ArrayHandle<vtkm::Float32> fieldArray;
       ArrayHandleCounting<vtkm::Id> vertexCountImplicitArray(
           0, 1, vdims.product());
-      vtkm::worklet::DispatcherMapField<TangleField> tangleFieldDispatcher(
-          TangleField(vdims, bounds));
-      tangleFieldDispatcher.Invoke(vertexCountImplicitArray, fieldArray);
+
+      vtkm::worklet::Invoker invoker(vtkm::cont::DeviceAdapterTagTBB{});
+      invoker(TangleField{vdims,bounds}, vertexCountImplicitArray, fieldArray);
 
       vtkm::Vec<vtkm::FloatDefault, 3> origin(0.0f, 0.0f, 0.0f);
       vtkm::Vec<vtkm::FloatDefault, 3> spacing(idims.x, idims.y, idims.z);

--- a/vtkm_dataset_sg.cpp
+++ b/vtkm_dataset_sg.cpp
@@ -29,16 +29,14 @@ namespace ospray {
       auto voxel_data  = std::make_shared<sg::DataVector1f>();
 
       using ArrayType      = vtkm::cont::ArrayHandle<vtkm::Float32>;
-      auto vtkmFieldPortal = data.GetField("field1")
+      const auto& array_storage = data.GetField("field1")
                                  .GetData()
                                  .Cast<ArrayType>()
-                                 .GetStorage()
-                                 .GetPortal();
+                                 .GetStorage();
 
       // TODO: figure out how to use VTKm's memory directly...ugh!
-      vtkm::cont::ArrayPortalToIterators vtkmIterators(vtkmFieldPortal);
-      std::copy(vtkmIterators.GetBegin(),
-                vtkmIterators.GetEnd(),
+      std::copy(array_storage.GetArray(),
+                array_storage.GetArray() + array_storage.GetNumberOfValues(),
                 std::back_inserter(voxel_data->v));
 
       voxel_data->setName("voxelData");


### PR DESCRIPTION
This updates the VTK-m plugin to use the `Invoker` which provides a better worklet dispatcher API. Additionally we use the `StorageBasic` pointers for copying.